### PR TITLE
Fix NoSuchFieldError: ANNOTATION_PROCESSOR_MODULE_PATH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply plugin: 'java'
 
 // Note:  For this setup to work you must follow the instructions outlined in the
-//       checker manual Section 25.3 "Building from Source" 
+//       checker manual Section 25.3 "Building from Source"
 // http://types.cs.washington.edu/checker-framework/current/checkers-manual.html#build-source
 
 ext {
@@ -89,6 +89,10 @@ test {
         systemProperties += ["emit.test.debug": 'true']
     }
 
+    if (isJava8) {
+        jvmArgs "-Xbootclasspath/p:${parentDir}/jsr308-langtools/cfmake/javac-jdk.jar"
+    }
+
     testLogging {
         // Always run the tests
         outputs.upToDateWhen { false }
@@ -128,8 +132,8 @@ compileJava {
 }
 
 // Exclude parts of the build directory that don't include classes from being packaged in
-// the jar file.  
-// IMPORTANT: If "libs" is packaged in the JAR file you end up with an infinitely 
+// the jar file.
+// IMPORTANT: If "libs" is packaged in the JAR file you end up with an infinitely
 // recursive jar task that will fill up your hard drive (eventually)
 jar {
     description = 'Makes a jar with ONLY the classes compiled for checker ' +

--- a/scripts/inference
+++ b/scripts/inference
@@ -17,5 +17,16 @@ then
     myDir="."
 fi
 
+ROOT=$(cd ${myDir}/../../ && pwd)
+
+langtoolsDir="$ROOT"/jsr308-langtools
+
 distDir=$myDir"/../dist"
-eval "java -classpath "$distDir"/checker.jar:"$distDir"/checker-framework-inference.jar  checkers.inference.InferenceLauncher " "$@"
+
+runtimeBCP=""
+java -version 2>&1 | grep version | grep 1.8 > /dev/null
+if [ $? -eq 0 ]; then
+    runtimeBCP="${langtoolsDir}/cfmake/javac-jdk.jar"
+fi
+
+eval "java -DInferenceLauncher.runtime.bcp="$runtimeBCP" -classpath "$distDir"/checker.jar:"$distDir"/checker-framework-inference.jar  checkers.inference.InferenceLauncher " "$@"

--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -58,7 +58,7 @@ fi
 runtimeBCP=""
 java -version 2>&1 | grep version | grep 1.8 > /dev/null
 if [ $? -eq 0 ]; then
-    runtimeBCP="${distDir}/javac.jar"
+    runtimeBCP="${langtoolsDir}/cfmake/javac-jdk.jar"
 fi
 
 eval "java" \

--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -63,7 +63,7 @@ fi
 
 eval "java" \
      "-DInferenceDevelLauncher.binary=${distDir} " \
-     "-DInferenceDevelLauncher.runtime.bcp=${runtimeBCP} " \
+     "-DInferenceLauncher.runtime.bcp=${runtimeBCP} " \
      "-DInferenceDevelLauncher.runtime.cp=${classpath} " \
      "-DInferenceDevelLauncher.annotated.jdk=${jdkPaths} " \
      "-classpath ${classpath} " \

--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -55,8 +55,15 @@ if [ "$CLASSPATH" != "" ] ; then
     classpath=${classpath}:${CLASSPATH}
 fi
 
+runtimeBCP=""
+java -version 2>&1 | grep version | grep 1.8 > /dev/null
+if [ $? -eq 0 ]; then
+    runtimeBCP="${distDir}/javac.jar"
+fi
+
 eval "java" \
      "-DInferenceDevelLauncher.binary=${distDir} " \
+     "-DInferenceDevelLauncher.runtime.bcp=${runtimeBCP} " \
      "-DInferenceDevelLauncher.runtime.cp=${classpath} " \
      "-DInferenceDevelLauncher.annotated.jdk=${jdkPaths} " \
      "-classpath ${classpath} " \

--- a/src/checkers/inference/InferenceDevelLauncher.java
+++ b/src/checkers/inference/InferenceDevelLauncher.java
@@ -73,7 +73,7 @@ public class InferenceDevelLauncher extends InferenceLauncher {
     // what used as bootclass to run the compiler
     @Override
     protected String getInferenceRuntimeBootclassPath() {
-        return "-Xbootclasspath/p:" + System.getProperty( RUNTIME_BCP );
+        return System.getProperty( RUNTIME_BCP );
     }
 
     @Override

--- a/src/checkers/inference/InferenceDevelLauncher.java
+++ b/src/checkers/inference/InferenceDevelLauncher.java
@@ -18,7 +18,7 @@ import org.checkerframework.javacutil.BugInCF;
  * locations that this class would use.
  *
  * TODO: We need to think how to enable {@code InferenceDevelLauncher} to find all necessary
- * locations by itself, so that we could remove the dependency of a shell script. After achieving 
+ * locations by itself, so that we could remove the dependency of a shell script. After achieving
  * this, we could also apply the similar solution to {@code CheckerDevelMain}.
  * @author charleszhuochen
  *
@@ -27,6 +27,7 @@ public class InferenceDevelLauncher extends InferenceLauncher {
 
     private static final String PROP_PREFIX = "InferenceDevelLauncher";
     private static final String BINARY = PROP_PREFIX + ".binary";
+    private static final String RUNTIME_BCP = PROP_PREFIX + ".runtime.bcp";
     private static final String RUNTIME_CP = PROP_PREFIX + ".runtime.cp";
     private static final String VERBOSE = PROP_PREFIX + ".verbose";
     private static final String ANNOTATED_JDK = PROP_PREFIX + ".annotated.jdk";
@@ -69,6 +70,12 @@ public class InferenceDevelLauncher extends InferenceLauncher {
         InferenceOptions.checkerJar = new File (InferenceOptions.distDir, "checker.jar");
     }
 
+    // what used as bootclass to run the compiler
+    @Override
+    protected String getInferenceRuntimeBootclassPath() {
+        return "-Xbootclasspath/p:" + System.getProperty( RUNTIME_BCP );
+    }
+
     @Override
     /**
      * return the eclipse output directory instead of jars.
@@ -85,7 +92,7 @@ public class InferenceDevelLauncher extends InferenceLauncher {
     }
 
     /**
-     * TODO: we need to extract the utility methods in {@code CheckerMain} and {@code CheckerDevelMain} out to an Util Class, 
+     * TODO: we need to extract the utility methods in {@code CheckerMain} and {@code CheckerDevelMain} out to an Util Class,
      * change their visibility to public, then we can reuse them in {@code InferenceLauncher}, {@code InferenceDevelLauncher}
      * and {@code InferenceMain}.
      *

--- a/src/checkers/inference/InferenceDevelLauncher.java
+++ b/src/checkers/inference/InferenceDevelLauncher.java
@@ -27,7 +27,6 @@ public class InferenceDevelLauncher extends InferenceLauncher {
 
     private static final String PROP_PREFIX = "InferenceDevelLauncher";
     private static final String BINARY = PROP_PREFIX + ".binary";
-    private static final String RUNTIME_BCP = PROP_PREFIX + ".runtime.bcp";
     private static final String RUNTIME_CP = PROP_PREFIX + ".runtime.cp";
     private static final String VERBOSE = PROP_PREFIX + ".verbose";
     private static final String ANNOTATED_JDK = PROP_PREFIX + ".annotated.jdk";
@@ -68,12 +67,6 @@ public class InferenceDevelLauncher extends InferenceLauncher {
         InferenceOptions.distDir = new File(System.getProperty( BINARY ));
         InferenceOptions.checkersInferenceDir = InferenceOptions.distDir.getParentFile();
         InferenceOptions.checkerJar = new File (InferenceOptions.distDir, "checker.jar");
-    }
-
-    // what used as bootclass to run the compiler
-    @Override
-    protected String getInferenceRuntimeBootclassPath() {
-        return System.getProperty( RUNTIME_BCP );
     }
 
     @Override

--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -37,6 +37,9 @@ public class InferenceLauncher {
     private final PrintStream outStream;
     private final PrintStream errStream;
 
+    private static final String PROP_PREFIX = "InferenceLauncher";
+    private static final String RUNTIME_BCP = PROP_PREFIX + ".runtime.bcp";
+
     public InferenceLauncher(PrintStream outStream, PrintStream errStream) {
         this.outStream = outStream;
         this.errStream = errStream;
@@ -154,7 +157,7 @@ public class InferenceLauncher {
         argList.addAll(getMemoryArgs());
 
         String bcp = getInferenceRuntimeBootclassPath();
-        if (bcp != null) {
+        if (bcp.length() > 0) {
             argList.add("-Xbootclasspath/p:" + bcp);
         }
 
@@ -382,7 +385,7 @@ public class InferenceLauncher {
 
     // what used as bootclass to run the compiler
     protected String getInferenceRuntimeBootclassPath() {
-        return null;
+        return System.getProperty( RUNTIME_BCP );
     }
 
     // what's used to run the compiler

--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -155,7 +155,7 @@ public class InferenceLauncher {
 
         String bcp = getInferenceRuntimeBootclassPath();
         if (bcp != null) {
-            argList.add(bcp);
+            argList.add("-Xbootclasspath/p:" + bcp);
         }
 
         argList.add("-classpath");

--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -157,7 +157,7 @@ public class InferenceLauncher {
         argList.addAll(getMemoryArgs());
 
         String bcp = getInferenceRuntimeBootclassPath();
-        if (bcp.length() > 0) {
+        if (bcp != null && !bcp.isEmpty()) {
             argList.add("-Xbootclasspath/p:" + bcp);
         }
 

--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -38,7 +38,7 @@ public class InferenceLauncher {
     private final PrintStream errStream;
 
     private static final String PROP_PREFIX = "InferenceLauncher";
-    private static final String RUNTIME_BCP = PROP_PREFIX + ".runtime.bcp";
+    private static final String RUNTIME_BCP_PROP = PROP_PREFIX + ".runtime.bcp";
 
     public InferenceLauncher(PrintStream outStream, PrintStream errStream) {
         this.outStream = outStream;
@@ -385,7 +385,7 @@ public class InferenceLauncher {
 
     // what used as bootclass to run the compiler
     protected String getInferenceRuntimeBootclassPath() {
-        return System.getProperty( RUNTIME_BCP );
+        return System.getProperty( RUNTIME_BCP_PROP );
     }
 
     // what's used to run the compiler

--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -153,6 +153,11 @@ public class InferenceLauncher {
         argList.add(java);
         argList.addAll(getMemoryArgs());
 
+        String bcp = getInferenceRuntimeBootclassPath();
+        if (bcp != null) {
+            argList.add(bcp);
+        }
+
         argList.add("-classpath");
         argList.add(getInferenceRuntimeClassPath());
 
@@ -162,7 +167,7 @@ public class InferenceLauncher {
 
         argList.addAll(
                 Arrays.asList(
-                        "-ea", "-ea:checkers.inference...", 
+                        "-ea", "-ea:checkers.inference...",
                         // TODO: enable assertions.
                         "-da:org.checkerframework.framework.flow...",
                         "checkers.inference.InferenceMain",
@@ -373,6 +378,11 @@ public class InferenceLauncher {
         }
         filePaths.add(InferenceOptions.targetclasspath);
         return filePaths;
+    }
+
+    // what used as bootclass to run the compiler
+    protected String getInferenceRuntimeBootclassPath() {
+        return null;
     }
 
     // what's used to run the compiler


### PR DESCRIPTION
This PR fixes the failure of CFI similar to https://github.com/eisop/annotation-tools/pull/2 . However the travis build will still fail due to other errors.

Adding `javac.jar` to [jdkPaths](https://github.com/eisop/checker-framework-inference/blob/02c8e5016943e9a5d9a1d4ab78ccafb493bec6ef/scripts/inference-dev#L33) somehow doesn't work, and moving [InferenceLauncher.java:180](https://github.com/eisop/checker-framework-inference/blob/02c8e5016943e9a5d9a1d4ab78ccafb493bec6ef/src/checkers/inference/InferenceLauncher.java#L180) to the front of the arg list seems to be leading to "corrupted byte code" and segment fault, so I added a new parameter `InferenceDevelLauncher.runtime.bcp` so as to place the required jar with JDK 9 updates to the front.

It looks like that [scripts/inference](https://github.com/eisop/checker-framework-inference/blob/master/scripts/inference) may also suffer from this error, but currently it can succeed; do I need to add a similar `runtimeBCP` to it?