### PR TITLE
Classloader magic

### DIFF
--- a/src/checkers/inference/CheckerFrameworkUtil.java
+++ b/src/checkers/inference/CheckerFrameworkUtil.java
@@ -1,11 +1,7 @@
 package checkers.inference;
 
 import java.io.PrintWriter;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.charset.Charset;
-import java.util.Objects;
 
 import javax.tools.JavaFileManager;
 
@@ -20,64 +16,22 @@ public class CheckerFrameworkUtil {
     public static boolean invokeCheckerFramework(String[] args, PrintWriter outputCapture) {
         Main compiler = new Main("javac", outputCapture);
 
-        // copied from https://github.com/google/error-prone-javac/blob/a53d069bbdb2c60232ed3811c19b65e41c3e60e0/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java#L159
+        // see https://github.com/google/error-prone-javac/blob/a53d069bbdb2c60232ed3811c19b65e41c3e60e0/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java#L159
         Context context = new Context();
-        ClassloaderMaskingFileManager.preRegister(context); // can't create it until Log has been set up
+        DummyJavacFileManager.preRegister(context);
         Result compilerResult = compiler.compile(args, context);
 
         return compilerResult == Result.OK;
     }
 
-    // copied from https://github.com/bazelbuild/bazel/blob/a1d758d615ffb0cc77518e37fed36b2950c32ca9/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java#L236
-    private static class ClassloaderMaskingFileManager extends JavacFileManager {
-        public ClassloaderMaskingFileManager(Context context, boolean register, Charset charset) {
+    private static class DummyJavacFileManager extends JavacFileManager {
+        public DummyJavacFileManager(Context context, boolean register, Charset charset) {
             super(context, register, charset);
         }
 
-        // adopted from https://github.com/google/error-prone-javac/blob/a53d069bbdb2c60232ed3811c19b65e41c3e60e0/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java#L137
         public static void preRegister(Context context) {
             context.put(JavaFileManager.class,
-                    (Factory<JavaFileManager>)c -> new ClassloaderMaskingFileManager(c, true, null));
+                    (Factory<JavaFileManager>)c -> new DummyJavacFileManager(c, true, null));
         }
-
-        @Override
-        protected ClassLoader getClassLoader(URL[] urls) {
-            return new URLClassLoader(
-                urls,
-                new ClassLoader(null) {
-                    @Override
-                    protected Class<?> findClass(String name) throws ClassNotFoundException {
-                    Class<?> c = Class.forName(name);
-                    if (name.startsWith("com.google.errorprone.")
-                        || name.startsWith("org.checkerframework.")
-                        || name.startsWith("checkers.inference")
-                        || name.startsWith("com.sun.source.")
-                        || name.startsWith("com.sun.tools.")) {
-                        return c;
-                    }
-                    if (c.getClassLoader() == null
-                        || Objects.equals(getClassLoaderName(c.getClassLoader()), "platform")) {
-                        return c;
-                    }
-                    throw new ClassNotFoundException(name);
-                    }
-                });
-        }
-
-        private static String getClassLoaderName(ClassLoader classLoader) {
-            Method method;
-            try {
-                method = ClassLoader.class.getMethod("getName");
-            } catch (NoSuchMethodException e) {
-                // ClassLoader#getName doesn't exist in JDK 8 and earlier.
-                return null;
-            }
-            try {
-                return (String) method.invoke(classLoader, new Object[] {});
-            } catch (ReflectiveOperationException e) {
-                throw new LinkageError(e.getMessage(), e);
-            }
-        }
-
     }
 }

--- a/src/checkers/inference/CheckerFrameworkUtil.java
+++ b/src/checkers/inference/CheckerFrameworkUtil.java
@@ -24,6 +24,13 @@ public class CheckerFrameworkUtil {
         return compilerResult == Result.OK;
     }
 
+    /**
+     * This class prevents InferenceMain from being loaded by the bootstrap class
+     * loader, resulting in two instances of the class of InferenceMain in both
+     * AppClassLoader and bootstrap class loader. See
+     * https://github.com/eisop/checker-framework-inference/pull/7 and
+     * https://github.com/eisop/checker-framework-inference/pull/9
+     */
     private static class DummyJavacFileManager extends JavacFileManager {
         public DummyJavacFileManager(Context context, boolean register, Charset charset) {
             super(context, register, charset);

--- a/src/checkers/inference/CheckerFrameworkUtil.java
+++ b/src/checkers/inference/CheckerFrameworkUtil.java
@@ -1,15 +1,83 @@
 package checkers.inference;
 
 import java.io.PrintWriter;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.Charset;
+import java.util.Objects;
 
+import javax.tools.JavaFileManager;
+
+import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.main.Main;
 import com.sun.tools.javac.main.Main.Result;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Context.Factory;
 
 public class CheckerFrameworkUtil {
 
     public static boolean invokeCheckerFramework(String[] args, PrintWriter outputCapture) {
         Main compiler = new Main("javac", outputCapture);
-        Result compilerResult = compiler.compile(args);
+
+        // copied from https://github.com/google/error-prone-javac/blob/a53d069bbdb2c60232ed3811c19b65e41c3e60e0/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java#L159
+        Context context = new Context();
+        ClassloaderMaskingFileManager.preRegister(context); // can't create it until Log has been set up
+        Result compilerResult = compiler.compile(args, context);
+
         return compilerResult == Result.OK;
+    }
+
+    // copied from https://github.com/bazelbuild/bazel/blob/a1d758d615ffb0cc77518e37fed36b2950c32ca9/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java#L236
+    private static class ClassloaderMaskingFileManager extends JavacFileManager {
+        public ClassloaderMaskingFileManager(Context context, boolean register, Charset charset) {
+            super(context, register, charset);
+        }
+
+        // adopted from https://github.com/google/error-prone-javac/blob/a53d069bbdb2c60232ed3811c19b65e41c3e60e0/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java#L137
+        public static void preRegister(Context context) {
+            context.put(JavaFileManager.class,
+                    (Factory<JavaFileManager>)c -> new ClassloaderMaskingFileManager(c, true, null));
+        }
+
+        @Override
+        protected ClassLoader getClassLoader(URL[] urls) {
+            return new URLClassLoader(
+                urls,
+                new ClassLoader(null) {
+                    @Override
+                    protected Class<?> findClass(String name) throws ClassNotFoundException {
+                    Class<?> c = Class.forName(name);
+                    if (name.startsWith("com.google.errorprone.")
+                        || name.startsWith("org.checkerframework.")
+                        || name.startsWith("checkers.inference")
+                        || name.startsWith("com.sun.source.")
+                        || name.startsWith("com.sun.tools.")) {
+                        return c;
+                    }
+                    if (c.getClassLoader() == null
+                        || Objects.equals(getClassLoaderName(c.getClassLoader()), "platform")) {
+                        return c;
+                    }
+                    throw new ClassNotFoundException(name);
+                    }
+                });
+        }
+
+        private static String getClassLoaderName(ClassLoader classLoader) {
+            Method method;
+            try {
+                method = ClassLoader.class.getMethod("getName");
+            } catch (NoSuchMethodException e) {
+                // ClassLoader#getName doesn't exist in JDK 8 and earlier.
+                return null;
+            }
+            try {
+                return (String) method.invoke(classLoader, new Object[] {});
+            } catch (ReflectiveOperationException e) {
+                throw new LinkageError(e.getMessage(), e);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This PR resolves https://github.com/eisop/checker-framework-inference/pull/7 and is necessary for https://github.com/opprop/do-like-javac/pull/16.

As commented [here](https://github.com/eisop/checker-framework-inference/pull/7#issuecomment-542422207), different classloaders are somehow used to load classes (i.e. IneferenceMain) before and during the compilation in [CheckerFrameworkUtil](https://github.com/zhangjiangqige/checker-framework-inference/blob/34e5f11f4956dff0f6e6594c9eadfbb7c6416945/src/checkers/inference/CheckerFrameworkUtil.java#L12). In Bazel, it seems that this similar kind of problem is met as well, and they used some kind of [classloader magic](https://github.com/bazelbuild/bazel/blob/a1d758d615ffb0cc77518e37fed36b2950c32ca9/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java#L236) to solve this classloader hierarchy issue, which is what's copied to this PR.

But this fix does look weird though...